### PR TITLE
Update for Hera with gnu/13.3.0 compiler and spack-stack/1.6.0

### DIFF
--- a/modulefiles/ufs_hera.gnu.lua
+++ b/modulefiles/ufs_hera.gnu.lua
@@ -2,12 +2,14 @@ help([[
 loads UFS Model prerequisites for Hera/GNU
 ]])
 
-prepend_path("MODULEPATH", "/scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.6.0/envs/unified-env-rocky8/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/scratch2/NCEPDEV/stmp1/role.epic/installs/gnu/modulefiles")
+prepend_path("MODULEPATH", "/scratch2/NCEPDEV/stmp1/role.epic/installs/openmpi/modulefiles")
+prepend_path("MODULEPATH", "/scratch2/NCEPDEV/stmp1/role.epic/spack-stack/spack-stack-1.6.0_gnu13/envs/ufs-wm-srw-rocky8/install/modulefiles/Core")
 
-stack_gnu_ver=os.getenv("stack_gnu_ver") or "9.2.0"
+stack_gnu_ver=os.getenv("stack_gnu_ver") or "13.3.0"
 load(pathJoin("stack-gcc", stack_gnu_ver))
 
-stack_openmpi_ver=os.getenv("stack_openmpi_ver") or "4.1.5"
+stack_openmpi_ver=os.getenv("stack_openmpi_ver") or "4.1.6"
 load(pathJoin("stack-openmpi", stack_openmpi_ver))
 
 cmake_ver=os.getenv("cmake_ver") or "3.23.1"
@@ -17,6 +19,9 @@ load("ufs_common")
 
 nccmp_ver=os.getenv("nccmp_ver") or "1.9.0.1"
 load(pathJoin("nccmp", nccmp_ver))
+
+prepend_path("CPPFLAGS", " -I/apps/slurm_hera/23.11.3/include/slurm"," ")
+prepend_path("LD_LIBRARY_PATH", "/apps/slurm_hera/23.11.3/lib")
 
 setenv("CC", "mpicc")
 setenv("CXX", "mpic++")

--- a/tests/fv3_conf/fv3_slurm.IN_hera
+++ b/tests/fv3_conf/fv3_slurm.IN_hera
@@ -39,6 +39,7 @@ export PSM_SHAREDCONTEXTS=1
 sync && sleep 1
 
 # shellcheck disable=SC2102
+#mpirun -n @[TASKS] ./fv3.exe
 srun --label -n @[TASKS] ./fv3.exe
 
 date_end=$(date)

--- a/tests/fv3_conf/fv3_slurm.IN_hera
+++ b/tests/fv3_conf/fv3_slurm.IN_hera
@@ -39,7 +39,6 @@ export PSM_SHAREDCONTEXTS=1
 sync && sleep 1
 
 # shellcheck disable=SC2102
-#mpirun -n @[TASKS] ./fv3.exe
 srun --label -n @[TASKS] ./fv3.exe
 
 date_end=$(date)


### PR DESCRIPTION

## Description:
An update for Hera with gnu/13.3.0 compiler and openmpi/4.1.6, spack-stack/1.6.0 environment ufs-wm-srw-rocky8:
/scratch2/NCEPDEV/stmp1/role.epic/spack-stack/spack-stack-1.6.0_gnu13/envs/ufs-wm-srw-rocky8/

The regression tests for Hera gnu compiler passed successfully, when "-c" option to generate a new baseline was used; log file attached:
[RegressionTests_hera.log.txt](https://github.com/user-attachments/files/15524281/RegressionTests_hera.log.txt)


### Commit Message:


### Priority:

* High: Reason: updating Hera compiler to a higher version, from 9.2.0 to 13.3.0, and spack-stack/1.6.0 that allows all the RT tests to pass.

## Git Tracking
### UFSWM:

* Closes [#2200](https://github.com/ufs-community/ufs-weather-model/issues/2200), [#2263](https://github.com/ufs-community/ufs-weather-model/issues/2263)

### Sub component Pull Requests:

* None

### UFSWM Blocking Dependencies:

* None

---
## Changes
### Regression Test Changes (Please commit test_changes.list):

New Baseline generated for Hera with gnu/13.3.0 compiler

* PR Updates/Changes Baselines.

### Input data Changes:

* None.


### Library Changes/Upgrades:

* No Updates
  
---
<!-- STOP!!! THE FOLLOWING IS FOR CODE MANAGERS ONLY. PLEASE DO NOT FILL OUT -->
## Testing Log:
- RDHPCS
  - [ ] Hera
  - [ ] Orion
  - [ ] Hercules
  - [ ] Jet
  - [ ] Gaea
  - [ ] Derecho
- WCOSS2
  - [ ] Dogwood/Cactus
  - [ ] Acorn
- [ ] CI
- [ ] opnReqTest (complete task if unnecessary)